### PR TITLE
🐛 FIX: AttributeError on spark < 2.4

### DIFF
--- a/06_testing/testing_dataframes.md
+++ b/06_testing/testing_dataframes.md
@@ -168,7 +168,13 @@ def _is_data_equal(df_actual: SparkDataFrame, df_expected: SparkDataFrame) -> bo
     df_actual_flat = _flatten_df(df_actual)
     df_expected_flat = _flatten_df(df_expected)
 
-    except_all = df_actual_flat.exceptAll(df_expected_flat)
+    try:
+        except_all = df_actual_flat.exceptAll(df_expected_flat)
+    except AttributeError:
+        # In spark 2.3 and below, we can't use exceptAll, so we use an anti-join
+        except_all = df_actual_flat.join(
+            df_expected_flat, on=df_actual_flat.columns, how="leftanti"
+        )
     return except_all.count() == 0
 
 


### PR DESCRIPTION
If you are unlucky enough to still be using Spark <2.4, `exceptAll` won't work. You will need to do an anti-left join instead.